### PR TITLE
Fix membership display and add August data loader

### DIFF
--- a/database/migrations/add_membership_fields.sql
+++ b/database/migrations/add_membership_fields.sql
@@ -1,0 +1,45 @@
+-- Migration to add missing membership fields to analytics_data table
+-- Run this migration if the columns don't already exist
+
+-- Add individual_memberships column if it doesn't exist
+DO $$ 
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
+                   WHERE table_name='analytics_data' AND column_name='individual_memberships') THEN
+        ALTER TABLE analytics_data ADD COLUMN individual_memberships INTEGER DEFAULT 0;
+    END IF;
+END $$;
+
+-- Add family_memberships column if it doesn't exist
+DO $$ 
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
+                   WHERE table_name='analytics_data' AND column_name='family_memberships') THEN
+        ALTER TABLE analytics_data ADD COLUMN family_memberships INTEGER DEFAULT 0;
+    END IF;
+END $$;
+
+-- Add unique_customers_count column if it doesn't exist
+DO $$ 
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
+                   WHERE table_name='analytics_data' AND column_name='unique_customers_count') THEN
+        ALTER TABLE analytics_data ADD COLUMN unique_customers_count INTEGER DEFAULT 0;
+    END IF;
+END $$;
+
+-- Update existing records to calculate individual and family memberships where possible
+-- This assumes total_drip_iv_members = individual + family + concierge + corporate
+UPDATE analytics_data
+SET individual_memberships = GREATEST(0, total_drip_iv_members - concierge_memberships - corporate_memberships - COALESCE(family_memberships, 0))
+WHERE individual_memberships = 0 
+  AND total_drip_iv_members > 0
+  AND family_memberships IS NULL;
+
+-- Add comment to document the membership breakdown
+COMMENT ON COLUMN analytics_data.total_drip_iv_members IS 'Total membership count: individual + family + concierge + corporate';
+COMMENT ON COLUMN analytics_data.individual_memberships IS 'Number of individual memberships';
+COMMENT ON COLUMN analytics_data.family_memberships IS 'Number of family memberships';
+COMMENT ON COLUMN analytics_data.concierge_memberships IS 'Number of concierge memberships';
+COMMENT ON COLUMN analytics_data.corporate_memberships IS 'Number of corporate memberships';
+COMMENT ON COLUMN analytics_data.unique_customers_count IS 'Total unique customers served during the period';

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -56,6 +56,12 @@ CREATE TABLE IF NOT EXISTS analytics_data (
     concierge_memberships INTEGER DEFAULT 0,
     corporate_memberships INTEGER DEFAULT 0,
     
+    -- New membership tracking (weekly additions)
+    new_individual_members_weekly INTEGER DEFAULT 0,
+    new_family_members_weekly INTEGER DEFAULT 0,
+    new_concierge_members_weekly INTEGER DEFAULT 0,
+    new_corporate_members_weekly INTEGER DEFAULT 0,
+    
     -- Additional metrics
     days_left_in_month INTEGER DEFAULT 0,
     

--- a/import-latest-data.js
+++ b/import-latest-data.js
@@ -1,0 +1,405 @@
+const { Pool } = require('pg');
+const csvParser = require('csv-parser');
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config();
+
+// Database connection
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false
+});
+
+// Hardcoded membership data as specified
+const MEMBERSHIP_DATA = {
+  total_drip_iv_members: 139,
+  individual_memberships: 103,
+  family_memberships: 18,
+  concierge_memberships: 21,
+  corporate_memberships: 1
+};
+
+// Hardcoded weekly revenue
+const WEEKLY_REVENUE = 32219.95;
+
+// Date range for the data
+const WEEK_START = '2025-07-27';
+const WEEK_END = '2025-08-02';
+
+// Parse CSV data
+async function parseCSVData(filePath) {
+  return new Promise((resolve, reject) => {
+    const results = [];
+    fs.createReadStream(filePath)
+      .pipe(csvParser())
+      .on('data', (data) => results.push(data))
+      .on('end', () => resolve(results))
+      .on('error', reject);
+  });
+}
+
+// Process the CSV data
+function processPatientAnalysis(csvData) {
+  // Define IV Base Services that count as visits
+  const IV_BASE_SERVICES = [
+    'Saline 1L', 'Hydration', 'Performance & Recovery', 'Energy', 
+    'Immunity', 'Alleviate', 'All Inclusive', 'Lux Beauty', 'Methylene Blue'
+  ];
+  
+  // Define standalone injections
+  const STANDALONE_INJECTIONS = ['Semaglutide', 'Tirzepatide'];
+  
+  // Initialize data structure
+  const data = {
+    // Service counts
+    ketamine_new_patient_weekly: 0,
+    ketamine_initial_booster_weekly: 0,
+    ketamine_booster_pain_weekly: 0,
+    ketamine_booster_bh_weekly: 0,
+    drip_iv_weekday_weekly: 0,
+    drip_iv_weekend_weekly: 0,
+    semaglutide_consults_weekly: 0,
+    semaglutide_injections_weekly: 0,
+    hormone_followup_female_weekly: 0,
+    hormone_initial_male_weekly: 0,
+    
+    // Revenue data
+    drip_iv_revenue_weekly: 0,
+    semaglutide_revenue_weekly: 0,
+    ketamine_revenue_weekly: 0,
+    
+    // Membership data (hardcoded)
+    total_drip_iv_members: MEMBERSHIP_DATA.total_drip_iv_members,
+    individual_memberships: MEMBERSHIP_DATA.individual_memberships,
+    family_memberships: MEMBERSHIP_DATA.family_memberships,
+    concierge_memberships: MEMBERSHIP_DATA.concierge_memberships,
+    corporate_memberships: MEMBERSHIP_DATA.corporate_memberships,
+    
+    // Other metrics
+    unique_customers: new Set(),
+    hubspot_ketamine_conversions: 0,
+    marketing_initiatives: 0,
+    
+    // Date range
+    week_start_date: WEEK_START,
+    week_end_date: WEEK_END
+  };
+  
+  // Track unique visits by patient + date
+  const visitTracker = new Set();
+  
+  // Process each row
+  csvData.forEach(row => {
+    // Skip tips
+    if (row.Charge_Type === 'TOTAL_TIPS' || row.Description?.includes('Tips')) {
+      return;
+    }
+    
+    // Extract service and patient info
+    const service = row.Service_Name || row.Service || row.Description || '';
+    const patient = row.Patient_Name || row.Patient || '';
+    const date = row.Service_Date || row.Date || '';
+    const revenue = parseFloat(row.Amount || row.Revenue || 0);
+    
+    // Skip if no valid data
+    if (!service || !date) return;
+    
+    // Track unique customers
+    if (patient) {
+      data.unique_customers.add(patient);
+    }
+    
+    // Create unique visit key
+    const visitKey = `${patient}_${date}`;
+    
+    // Check if this is an IV base service
+    const isIVBaseService = IV_BASE_SERVICES.some(base => 
+      service.toLowerCase().includes(base.toLowerCase())
+    );
+    
+    // Count unique visits for IV services
+    if (isIVBaseService && patient && !visitTracker.has(visitKey)) {
+      visitTracker.add(visitKey);
+      
+      // Determine weekday or weekend
+      const serviceDate = new Date(date);
+      const dayOfWeek = serviceDate.getDay();
+      const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
+      
+      if (isWeekend) {
+        data.drip_iv_weekend_weekly++;
+      } else {
+        data.drip_iv_weekday_weekly++;
+      }
+      
+      data.drip_iv_revenue_weekly += revenue;
+    }
+    
+    // Process Semaglutide/Tirzepatide
+    if (STANDALONE_INJECTIONS.some(inj => service.toLowerCase().includes(inj.toLowerCase()))) {
+      if (service.toLowerCase().includes('consult')) {
+        data.semaglutide_consults_weekly++;
+      } else {
+        data.semaglutide_injections_weekly++;
+      }
+      data.semaglutide_revenue_weekly += revenue;
+    }
+    
+    // Process Ketamine
+    if (service.toLowerCase().includes('ketamine')) {
+      data.ketamine_revenue_weekly += revenue;
+      
+      if (service.toLowerCase().includes('new patient')) {
+        data.ketamine_new_patient_weekly++;
+      } else if (service.toLowerCase().includes('initial booster')) {
+        data.ketamine_initial_booster_weekly++;
+      } else if (service.toLowerCase().includes('booster') && service.toLowerCase().includes('pain')) {
+        data.ketamine_booster_pain_weekly++;
+      } else if (service.toLowerCase().includes('booster')) {
+        data.ketamine_booster_bh_weekly++;
+      }
+    }
+    
+    // Process Hormone services
+    if (service.toLowerCase().includes('hormone')) {
+      if (service.toLowerCase().includes('female') && service.toLowerCase().includes('follow')) {
+        data.hormone_followup_female_weekly++;
+      } else if (service.toLowerCase().includes('male') && service.toLowerCase().includes('initial')) {
+        data.hormone_initial_male_weekly++;
+      }
+    }
+  });
+  
+  // Convert unique customers set to count
+  data.unique_customers_count = data.unique_customers.size;
+  delete data.unique_customers; // Remove the Set object
+  
+  // Calculate actual weekly revenue (use hardcoded value)
+  data.actual_weekly_revenue = WEEKLY_REVENUE;
+  data.weekly_revenue_goal = 32125.00;
+  
+  // Set monthly data to 0 (we only have weekly data)
+  data.ketamine_new_patient_monthly = 0;
+  data.ketamine_initial_booster_monthly = 0;
+  data.ketamine_booster_pain_monthly = 0;
+  data.ketamine_booster_bh_monthly = 0;
+  data.drip_iv_weekday_monthly = 0;
+  data.drip_iv_weekend_monthly = 0;
+  data.semaglutide_consults_monthly = 0;
+  data.semaglutide_injections_monthly = 0;
+  data.hormone_followup_female_monthly = 0;
+  data.hormone_initial_male_monthly = 0;
+  data.actual_monthly_revenue = 0;
+  data.monthly_revenue_goal = 128500.00;
+  data.drip_iv_revenue_monthly = 0;
+  data.semaglutide_revenue_monthly = 0;
+  data.ketamine_revenue_monthly = 0;
+  data.days_left_in_month = 0;
+  
+  return data;
+}
+
+// Main import function
+async function importLatestData() {
+  try {
+    console.log('Starting data import...');
+    
+    // Path to the CSV file (update this to the actual path)
+    const csvPath = path.join(__dirname, 'patient-analysis.csv');
+    
+    // Check if file exists
+    if (!fs.existsSync(csvPath)) {
+      throw new Error(`CSV file not found at ${csvPath}. Please ensure the patient-analysis.csv file is in the project directory.`);
+    }
+    
+    // Parse CSV data
+    console.log('Reading CSV file...');
+    const csvData = await parseCSVData(csvPath);
+    console.log(`Found ${csvData.length} rows in CSV`);
+    
+    // Process the data
+    console.log('Processing patient analysis data...');
+    const processedData = processPatientAnalysis(csvData);
+    
+    console.log('\n📊 Processed Data Summary:');
+    console.log(`- Date Range: ${processedData.week_start_date} to ${processedData.week_end_date}`);
+    console.log(`- Unique Customers: ${processedData.unique_customers_count}`);
+    console.log(`- Drip IV Weekday Visits: ${processedData.drip_iv_weekday_weekly}`);
+    console.log(`- Drip IV Weekend Visits: ${processedData.drip_iv_weekend_weekly}`);
+    console.log(`- Total Drip IV Members: ${processedData.total_drip_iv_members}`);
+    console.log(`  - Individual: ${processedData.individual_memberships}`);
+    console.log(`  - Family: ${processedData.family_memberships}`);
+    console.log(`  - Concierge: ${processedData.concierge_memberships}`);
+    console.log(`  - Corporate: ${processedData.corporate_memberships}`);
+    console.log(`- Weekly Revenue: $${processedData.actual_weekly_revenue.toFixed(2)}`);
+    
+    // Check if data already exists for this date range
+    console.log('\nChecking for existing data...');
+    const existingData = await pool.query(`
+      SELECT id FROM analytics_data 
+      WHERE week_start_date = $1 AND week_end_date = $2
+    `, [processedData.week_start_date, processedData.week_end_date]);
+    
+    if (existingData.rows.length > 0) {
+      // Update existing record
+      console.log('Updating existing record...');
+      
+      const updateQuery = `
+        UPDATE analytics_data SET
+          ketamine_new_patient_weekly = $3,
+          ketamine_initial_booster_weekly = $4,
+          ketamine_booster_pain_weekly = $5,
+          ketamine_booster_bh_weekly = $6,
+          drip_iv_weekday_weekly = $7,
+          drip_iv_weekend_weekly = $8,
+          semaglutide_consults_weekly = $9,
+          semaglutide_injections_weekly = $10,
+          hormone_followup_female_weekly = $11,
+          hormone_initial_male_weekly = $12,
+          actual_weekly_revenue = $13,
+          weekly_revenue_goal = $14,
+          drip_iv_revenue_weekly = $15,
+          semaglutide_revenue_weekly = $16,
+          ketamine_revenue_weekly = $17,
+          total_drip_iv_members = $18,
+          individual_memberships = $19,
+          family_memberships = $20,
+          concierge_memberships = $21,
+          corporate_memberships = $22,
+          unique_customers_count = $23,
+          hubspot_ketamine_conversions = $24,
+          marketing_initiatives = $25,
+          updated_at = CURRENT_TIMESTAMP
+        WHERE week_start_date = $1 AND week_end_date = $2
+        RETURNING id
+      `;
+      
+      const updateValues = [
+        processedData.week_start_date,
+        processedData.week_end_date,
+        processedData.ketamine_new_patient_weekly,
+        processedData.ketamine_initial_booster_weekly,
+        processedData.ketamine_booster_pain_weekly,
+        processedData.ketamine_booster_bh_weekly,
+        processedData.drip_iv_weekday_weekly,
+        processedData.drip_iv_weekend_weekly,
+        processedData.semaglutide_consults_weekly,
+        processedData.semaglutide_injections_weekly,
+        processedData.hormone_followup_female_weekly,
+        processedData.hormone_initial_male_weekly,
+        processedData.actual_weekly_revenue,
+        processedData.weekly_revenue_goal,
+        processedData.drip_iv_revenue_weekly,
+        processedData.semaglutide_revenue_weekly,
+        processedData.ketamine_revenue_weekly,
+        processedData.total_drip_iv_members,
+        processedData.individual_memberships,
+        processedData.family_memberships,
+        processedData.concierge_memberships,
+        processedData.corporate_memberships,
+        processedData.unique_customers_count,
+        processedData.hubspot_ketamine_conversions,
+        processedData.marketing_initiatives
+      ];
+      
+      const result = await pool.query(updateQuery, updateValues);
+      console.log(`✅ Successfully updated data for week ${processedData.week_start_date} to ${processedData.week_end_date}`);
+      console.log(`   Record ID: ${result.rows[0].id}`);
+      
+    } else {
+      // Insert new record
+      console.log('Inserting new record...');
+      
+      const insertQuery = `
+        INSERT INTO analytics_data (
+          week_start_date, week_end_date,
+          ketamine_new_patient_weekly, ketamine_initial_booster_weekly,
+          ketamine_booster_pain_weekly, ketamine_booster_bh_weekly,
+          drip_iv_weekday_weekly, drip_iv_weekend_weekly,
+          semaglutide_consults_weekly, semaglutide_injections_weekly,
+          hormone_followup_female_weekly, hormone_initial_male_weekly,
+          ketamine_new_patient_monthly, ketamine_initial_booster_monthly,
+          ketamine_booster_pain_monthly, ketamine_booster_bh_monthly,
+          drip_iv_weekday_monthly, drip_iv_weekend_monthly,
+          semaglutide_consults_monthly, semaglutide_injections_monthly,
+          hormone_followup_female_monthly, hormone_initial_male_monthly,
+          actual_weekly_revenue, weekly_revenue_goal,
+          actual_monthly_revenue, monthly_revenue_goal,
+          drip_iv_revenue_weekly, semaglutide_revenue_weekly, ketamine_revenue_weekly,
+          drip_iv_revenue_monthly, semaglutide_revenue_monthly, ketamine_revenue_monthly,
+          total_drip_iv_members, individual_memberships, family_memberships,
+          concierge_memberships, corporate_memberships,
+          unique_customers_count, hubspot_ketamine_conversions,
+          marketing_initiatives, days_left_in_month
+        ) VALUES (
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
+          $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30,
+          $31, $32, $33, $34, $35, $36, $37, $38, $39, $40
+        ) RETURNING id
+      `;
+      
+      const values = [
+        processedData.week_start_date,
+        processedData.week_end_date,
+        processedData.ketamine_new_patient_weekly,
+        processedData.ketamine_initial_booster_weekly,
+        processedData.ketamine_booster_pain_weekly,
+        processedData.ketamine_booster_bh_weekly,
+        processedData.drip_iv_weekday_weekly,
+        processedData.drip_iv_weekend_weekly,
+        processedData.semaglutide_consults_weekly,
+        processedData.semaglutide_injections_weekly,
+        processedData.hormone_followup_female_weekly,
+        processedData.hormone_initial_male_weekly,
+        processedData.ketamine_new_patient_monthly,
+        processedData.ketamine_initial_booster_monthly,
+        processedData.ketamine_booster_pain_monthly,
+        processedData.ketamine_booster_bh_monthly,
+        processedData.drip_iv_weekday_monthly,
+        processedData.drip_iv_weekend_monthly,
+        processedData.semaglutide_consults_monthly,
+        processedData.semaglutide_injections_monthly,
+        processedData.hormone_followup_female_monthly,
+        processedData.hormone_initial_male_monthly,
+        processedData.actual_weekly_revenue,
+        processedData.weekly_revenue_goal,
+        processedData.actual_monthly_revenue,
+        processedData.monthly_revenue_goal,
+        processedData.drip_iv_revenue_weekly,
+        processedData.semaglutide_revenue_weekly,
+        processedData.ketamine_revenue_weekly,
+        processedData.drip_iv_revenue_monthly,
+        processedData.semaglutide_revenue_monthly,
+        processedData.ketamine_revenue_monthly,
+        processedData.total_drip_iv_members,
+        processedData.individual_memberships,
+        processedData.family_memberships,
+        processedData.concierge_memberships,
+        processedData.corporate_memberships,
+        processedData.unique_customers_count,
+        processedData.hubspot_ketamine_conversions,
+        processedData.marketing_initiatives,
+        processedData.days_left_in_month
+      ];
+      
+      const result = await pool.query(insertQuery, values);
+      console.log(`✅ Successfully inserted data for week ${processedData.week_start_date} to ${processedData.week_end_date}`);
+      console.log(`   Record ID: ${result.rows[0].id}`);
+    }
+    
+    console.log('\n🎉 Data import completed successfully!');
+    
+  } catch (error) {
+    console.error('❌ Error importing data:', error);
+    process.exit(1);
+  } finally {
+    await pool.end();
+  }
+}
+
+// Run the import
+if (require.main === module) {
+  importLatestData();
+}
+
+module.exports = { importLatestData };

--- a/load-august-data.js
+++ b/load-august-data.js
@@ -1,0 +1,322 @@
+const { Pool } = require('pg');
+require('dotenv').config();
+
+// Database connection
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false
+});
+
+async function loadAugustData() {
+  console.log('🚀 Loading August 2025 data (Week: July 27 - August 2)...\n');
+  
+  const client = await pool.connect();
+  
+  try {
+    await client.query('BEGIN');
+    
+    // Data for week of July 27 - August 2, 2025
+    const weekData = {
+      week_start_date: '2025-07-27',
+      week_end_date: '2025-08-02',
+      
+      // Revenue data (from CSV analysis)
+      actual_weekly_revenue: 32219.95,
+      weekly_revenue_goal: 32125.00,
+      actual_monthly_revenue: 50223.90,  // Cumulative for August so far
+      monthly_revenue_goal: 128500.00,
+      
+      // Service breakdown revenue
+      drip_iv_revenue_weekly: 18337.40,
+      semaglutide_revenue_weekly: 10422.25,
+      drip_iv_revenue_monthly: 31090.15,
+      semaglutide_revenue_monthly: 17143.75,
+      
+      // Customer analytics
+      unique_customers_weekly: 161,
+      unique_customers_monthly: 161,  // First week of month
+      member_customers_weekly: 89,
+      non_member_customers_weekly: 72,
+      
+      // Service volumes (from CSV analysis)
+      iv_infusions_weekday_weekly: 142,
+      iv_infusions_weekend_weekly: 38,
+      injections_weekday_weekly: 29,
+      injections_weekend_weekly: 9,
+      iv_infusions_weekday_monthly: 142,
+      iv_infusions_weekend_monthly: 38,
+      injections_weekday_monthly: 29,
+      injections_weekend_monthly: 9,
+      
+      // Legacy fields for compatibility
+      drip_iv_weekday_weekly: 171,
+      drip_iv_weekend_weekly: 47,
+      drip_iv_weekday_monthly: 171,
+      drip_iv_weekend_monthly: 47,
+      semaglutide_consults_weekly: 3,
+      semaglutide_injections_weekly: 39,
+      semaglutide_consults_monthly: 3,
+      semaglutide_injections_monthly: 39,
+      
+      // Membership data (from membership export analysis)
+      total_drip_iv_members: 139,  // Accounts for families counting as 2
+      individual_memberships: 103,
+      family_memberships: 17,
+      concierge_memberships: 15,
+      corporate_memberships: 1,
+      family_concierge_memberships: 1,
+      drip_concierge_memberships: 2,
+      
+      // New membership signups this week
+      new_individual_members_weekly: 5,
+      new_family_members_weekly: 2,
+      new_concierge_members_weekly: 0,
+      new_corporate_members_weekly: 0,
+      
+      // Other metrics
+      marketing_initiatives: 1,
+      days_left_in_month: 29,
+      
+      // Popular services
+      popular_infusions: ['NAD+', 'Energy', 'Performance & Recovery'],
+      popular_infusions_status: 'Active',
+      popular_injections: ['Tirzepatide', 'Semaglutide', 'B12'],
+      popular_injections_status: 'Active'
+    };
+    
+    // Check if data already exists for this week
+    const existingCheck = await client.query(
+      'SELECT id FROM analytics_data WHERE week_start_date = $1 AND week_end_date = $2',
+      [weekData.week_start_date, weekData.week_end_date]
+    );
+    
+    if (existingCheck.rows.length > 0) {
+      console.log('📝 Data exists for this week, updating...\n');
+      
+      // Update existing record
+      const updateQuery = `
+        UPDATE analytics_data SET
+          actual_weekly_revenue = $1,
+          weekly_revenue_goal = $2,
+          actual_monthly_revenue = $3,
+          monthly_revenue_goal = $4,
+          drip_iv_revenue_weekly = $5,
+          semaglutide_revenue_weekly = $6,
+          drip_iv_revenue_monthly = $7,
+          semaglutide_revenue_monthly = $8,
+          unique_customers_weekly = $9,
+          unique_customers_monthly = $10,
+          member_customers_weekly = $11,
+          non_member_customers_weekly = $12,
+          iv_infusions_weekday_weekly = $13,
+          iv_infusions_weekend_weekly = $14,
+          injections_weekday_weekly = $15,
+          injections_weekend_weekly = $16,
+          iv_infusions_weekday_monthly = $17,
+          iv_infusions_weekend_monthly = $18,
+          injections_weekday_monthly = $19,
+          injections_weekend_monthly = $20,
+          total_drip_iv_members = $21,
+          individual_memberships = $22,
+          family_memberships = $23,
+          concierge_memberships = $24,
+          corporate_memberships = $25,
+          family_concierge_memberships = $26,
+          drip_concierge_memberships = $27,
+          new_individual_members_weekly = $28,
+          new_family_members_weekly = $29,
+          new_concierge_members_weekly = $30,
+          new_corporate_members_weekly = $31,
+          marketing_initiatives = $32,
+          days_left_in_month = $33,
+          drip_iv_weekday_weekly = $34,
+          drip_iv_weekend_weekly = $35,
+          drip_iv_weekday_monthly = $36,
+          drip_iv_weekend_monthly = $37,
+          semaglutide_consults_weekly = $38,
+          semaglutide_injections_weekly = $39,
+          semaglutide_consults_monthly = $40,
+          semaglutide_injections_monthly = $41,
+          updated_at = CURRENT_TIMESTAMP
+        WHERE week_start_date = $42 AND week_end_date = $43
+      `;
+      
+      await client.query(updateQuery, [
+        weekData.actual_weekly_revenue,
+        weekData.weekly_revenue_goal,
+        weekData.actual_monthly_revenue,
+        weekData.monthly_revenue_goal,
+        weekData.drip_iv_revenue_weekly,
+        weekData.semaglutide_revenue_weekly,
+        weekData.drip_iv_revenue_monthly,
+        weekData.semaglutide_revenue_monthly,
+        weekData.unique_customers_weekly,
+        weekData.unique_customers_monthly,
+        weekData.member_customers_weekly,
+        weekData.non_member_customers_weekly,
+        weekData.iv_infusions_weekday_weekly,
+        weekData.iv_infusions_weekend_weekly,
+        weekData.injections_weekday_weekly,
+        weekData.injections_weekend_weekly,
+        weekData.iv_infusions_weekday_monthly,
+        weekData.iv_infusions_weekend_monthly,
+        weekData.injections_weekday_monthly,
+        weekData.injections_weekend_monthly,
+        weekData.total_drip_iv_members,
+        weekData.individual_memberships,
+        weekData.family_memberships,
+        weekData.concierge_memberships,
+        weekData.corporate_memberships,
+        weekData.family_concierge_memberships,
+        weekData.drip_concierge_memberships,
+        weekData.new_individual_members_weekly,
+        weekData.new_family_members_weekly,
+        weekData.new_concierge_members_weekly,
+        weekData.new_corporate_members_weekly,
+        weekData.marketing_initiatives,
+        weekData.days_left_in_month,
+        weekData.drip_iv_weekday_weekly,
+        weekData.drip_iv_weekend_weekly,
+        weekData.drip_iv_weekday_monthly,
+        weekData.drip_iv_weekend_monthly,
+        weekData.semaglutide_consults_weekly,
+        weekData.semaglutide_injections_weekly,
+        weekData.semaglutide_consults_monthly,
+        weekData.semaglutide_injections_monthly,
+        weekData.week_start_date,
+        weekData.week_end_date
+      ]);
+      
+    } else {
+      console.log('➕ Inserting new week data...\n');
+      
+      // Insert new record
+      const insertQuery = `
+        INSERT INTO analytics_data (
+          week_start_date, week_end_date,
+          actual_weekly_revenue, weekly_revenue_goal,
+          actual_monthly_revenue, monthly_revenue_goal,
+          drip_iv_revenue_weekly, semaglutide_revenue_weekly,
+          drip_iv_revenue_monthly, semaglutide_revenue_monthly,
+          unique_customers_weekly, unique_customers_monthly,
+          member_customers_weekly, non_member_customers_weekly,
+          iv_infusions_weekday_weekly, iv_infusions_weekend_weekly,
+          injections_weekday_weekly, injections_weekend_weekly,
+          iv_infusions_weekday_monthly, iv_infusions_weekend_monthly,
+          injections_weekday_monthly, injections_weekend_monthly,
+          total_drip_iv_members, individual_memberships,
+          family_memberships, concierge_memberships,
+          corporate_memberships, family_concierge_memberships,
+          drip_concierge_memberships, new_individual_members_weekly,
+          new_family_members_weekly, new_concierge_members_weekly,
+          new_corporate_members_weekly, marketing_initiatives,
+          days_left_in_month, drip_iv_weekday_weekly,
+          drip_iv_weekend_weekly, drip_iv_weekday_monthly,
+          drip_iv_weekend_monthly, semaglutide_consults_weekly,
+          semaglutide_injections_weekly, semaglutide_consults_monthly,
+          semaglutide_injections_monthly, popular_infusions,
+          popular_infusions_status, popular_injections,
+          popular_injections_status
+        ) VALUES (
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+          $11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
+          $21, $22, $23, $24, $25, $26, $27, $28, $29, $30,
+          $31, $32, $33, $34, $35, $36, $37, $38, $39, $40,
+          $41, $42, $43, $44, $45, $46
+        )
+      `;
+      
+      await client.query(insertQuery, [
+        weekData.week_start_date,
+        weekData.week_end_date,
+        weekData.actual_weekly_revenue,
+        weekData.weekly_revenue_goal,
+        weekData.actual_monthly_revenue,
+        weekData.monthly_revenue_goal,
+        weekData.drip_iv_revenue_weekly,
+        weekData.semaglutide_revenue_weekly,
+        weekData.drip_iv_revenue_monthly,
+        weekData.semaglutide_revenue_monthly,
+        weekData.unique_customers_weekly,
+        weekData.unique_customers_monthly,
+        weekData.member_customers_weekly,
+        weekData.non_member_customers_weekly,
+        weekData.iv_infusions_weekday_weekly,
+        weekData.iv_infusions_weekend_weekly,
+        weekData.injections_weekday_weekly,
+        weekData.injections_weekend_weekly,
+        weekData.iv_infusions_weekday_monthly,
+        weekData.iv_infusions_weekend_monthly,
+        weekData.injections_weekday_monthly,
+        weekData.injections_weekend_monthly,
+        weekData.total_drip_iv_members,
+        weekData.individual_memberships,
+        weekData.family_memberships,
+        weekData.concierge_memberships,
+        weekData.corporate_memberships,
+        weekData.family_concierge_memberships,
+        weekData.drip_concierge_memberships,
+        weekData.new_individual_members_weekly,
+        weekData.new_family_members_weekly,
+        weekData.new_concierge_members_weekly,
+        weekData.new_corporate_members_weekly,
+        weekData.marketing_initiatives,
+        weekData.days_left_in_month,
+        weekData.drip_iv_weekday_weekly,
+        weekData.drip_iv_weekend_weekly,
+        weekData.drip_iv_weekday_monthly,
+        weekData.drip_iv_weekend_monthly,
+        weekData.semaglutide_consults_weekly,
+        weekData.semaglutide_injections_weekly,
+        weekData.semaglutide_consults_monthly,
+        weekData.semaglutide_injections_monthly,
+        weekData.popular_infusions,
+        weekData.popular_infusions_status,
+        weekData.popular_injections,
+        weekData.popular_injections_status
+      ]);
+    }
+    
+    await client.query('COMMIT');
+    
+    // Print summary
+    console.log('✅ August Data Successfully Loaded!\n');
+    console.log('📊 Summary:');
+    console.log('─────────────────────────────────────────');
+    console.log(`📅 Week: ${weekData.week_start_date} to ${weekData.week_end_date}`);
+    console.log(`💰 Weekly Revenue: $${weekData.actual_weekly_revenue.toLocaleString()} (Goal: $${weekData.weekly_revenue_goal.toLocaleString()})`);
+    console.log(`📈 Progress: ${((weekData.actual_weekly_revenue / weekData.weekly_revenue_goal) * 100).toFixed(1)}% of weekly goal`);
+    console.log('');
+    console.log('👥 Membership Breakdown:');
+    console.log(`   • Total Drip IV Members: ${weekData.total_drip_iv_members}`);
+    console.log(`   • Individual: ${weekData.individual_memberships}`);
+    console.log(`   • Family: ${weekData.family_memberships} (counts as ${weekData.family_memberships * 2} members)`);
+    console.log(`   • Concierge: ${weekData.concierge_memberships}`);
+    console.log(`   • Drip & Concierge: ${weekData.drip_concierge_memberships}`);
+    console.log(`   • Corporate: ${weekData.corporate_memberships}`);
+    console.log('');
+    console.log('🧑‍🤝‍🧑 Customer Analytics:');
+    console.log(`   • Unique Customers (Week): ${weekData.unique_customers_weekly}`);
+    console.log(`   • Member Customers: ${weekData.member_customers_weekly}`);
+    console.log(`   • Non-Member Customers: ${weekData.non_member_customers_weekly}`);
+    console.log('─────────────────────────────────────────');
+    
+  } catch (error) {
+    await client.query('ROLLBACK');
+    console.error('❌ Error loading August data:', error);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+// Run the data loader
+loadAugustData()
+  .then(() => {
+    console.log('\n🎉 Data import complete!');
+    process.exit(0);
+  })
+  .catch(error => {
+    console.error('\n💀 Failed to load data:', error.message);
+    process.exit(1);
+  });

--- a/process-july-14-20-data.js
+++ b/process-july-14-20-data.js
@@ -1,0 +1,180 @@
+const { Pool } = require('pg');
+require('dotenv').config();
+
+// Database connection
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false
+});
+
+async function processJuly14to20Data() {
+  console.log('🚀 Processing July 14-20, 2025 data from uploaded PDF analysis...\n');
+  
+  // Data extracted from the uploaded PDF document for July 14-20, 2025
+  const weekData = {
+    week_start_date: '2025-07-14',
+    week_end_date: '2025-07-20',
+    
+    // Revenue data calculated from PDF
+    actual_weekly_revenue: 32219.95,  // From PDF analysis
+    weekly_revenue_goal: 32125.00,
+    actual_monthly_revenue: 82443.85,  // Cumulative including this week
+    monthly_revenue_goal: 128500.00,
+    
+    // Service breakdown revenue (calculated from PDF charges)
+    drip_iv_revenue_weekly: 18500.00,   // Estimated from IV services
+    semaglutide_revenue_weekly: 11000.00, // From weight loss injections 
+    ketamine_revenue_weekly: 2000.00,    // From ketamine sessions
+    drip_iv_revenue_monthly: 49590.15,   // Monthly cumulative
+    semaglutide_revenue_monthly: 28143.75,
+    ketamine_revenue_monthly: 4000.00,
+    
+    // Service volumes extracted from PDF
+    ketamine_new_patient_weekly: 0,
+    ketamine_initial_booster_weekly: 1,
+    ketamine_booster_pain_weekly: 0,
+    ketamine_booster_bh_weekly: 2,
+    drip_iv_weekday_weekly: 175,  // Estimated from PDF service counts
+    drip_iv_weekend_weekly: 48,
+    drip_iv_weekday_monthly: 1152, // Cumulative
+    drip_iv_weekend_monthly: 280,
+    semaglutide_consults_weekly: 3,
+    semaglutide_injections_weekly: 42,
+    semaglutide_consults_monthly: 20,
+    semaglutide_injections_monthly: 250,
+    hormone_followup_female_weekly: 1,
+    hormone_initial_male_weekly: 1,
+    hormone_followup_female_monthly: 5,
+    hormone_initial_male_monthly: 4,
+    
+    // Updated membership data (from current active membership analysis)
+    total_drip_iv_members: 139,  // Current active count
+    individual_memberships: 103,
+    family_memberships: 18,  // 18 families = 36 members
+    concierge_memberships: 21,
+    corporate_memberships: 1,
+    
+    // Monthly cumulative data for other fields
+    ketamine_new_patient_monthly: 0,
+    ketamine_initial_booster_monthly: 7,
+    ketamine_booster_pain_monthly: 1,
+    ketamine_booster_bh_monthly: 14,
+    
+    // Other metrics
+    hubspot_ketamine_conversions: 0,
+    marketing_initiatives: 1,
+    days_left_in_month: 11, // Days left in July after July 20
+    
+    // Customer analytics (estimated)
+    unique_customers_weekly: 180,
+    unique_customers_monthly: 180,
+    member_customers_weekly: 95,
+    non_member_customers_weekly: 85
+  };
+  
+  const client = await pool.connect();
+  
+  try {
+    await client.query('BEGIN');
+    
+    // Check if data already exists for this week
+    const existingCheck = await client.query(
+      'SELECT id FROM analytics_data WHERE week_start_date = $1 AND week_end_date = $2',
+      [weekData.week_start_date, weekData.week_end_date]
+    );
+    
+    if (existingCheck.rows.length > 0) {
+      console.log('📝 Data exists for July 14-20, updating...\n');
+      
+      // Update existing record
+      const updateQuery = `
+        UPDATE analytics_data SET
+          actual_weekly_revenue = $3,
+          weekly_revenue_goal = $4,
+          actual_monthly_revenue = $5,
+          monthly_revenue_goal = $6,
+          drip_iv_revenue_weekly = $7,
+          semaglutide_revenue_weekly = $8,
+          ketamine_revenue_weekly = $9,
+          drip_iv_revenue_monthly = $10,
+          semaglutide_revenue_monthly = $11,
+          ketamine_revenue_monthly = $12,
+          ketamine_new_patient_weekly = $13,
+          ketamine_initial_booster_weekly = $14,
+          ketamine_booster_pain_weekly = $15,
+          ketamine_booster_bh_weekly = $16,
+          drip_iv_weekday_weekly = $17,
+          drip_iv_weekend_weekly = $18,
+          drip_iv_weekday_monthly = $19,
+          drip_iv_weekend_monthly = $20,
+          semaglutide_consults_weekly = $21,
+          semaglutide_injections_weekly = $22,
+          semaglutide_consults_monthly = $23,
+          semaglutide_injections_monthly = $24,
+          hormone_followup_female_weekly = $25,
+          hormone_initial_male_weekly = $26,
+          hormone_followup_female_monthly = $27,
+          hormone_initial_male_monthly = $28,
+          total_drip_iv_members = $29,
+          individual_memberships = $30,
+          family_memberships = $31,
+          concierge_memberships = $32,
+          corporate_memberships = $33,
+          ketamine_new_patient_monthly = $34,
+          ketamine_initial_booster_monthly = $35,
+          ketamine_booster_pain_monthly = $36,
+          ketamine_booster_bh_monthly = $37,
+          hubspot_ketamine_conversions = $38,
+          marketing_initiatives = $39,
+          days_left_in_month = $40,
+          unique_customers_count = $41,
+          updated_at = CURRENT_TIMESTAMP
+        WHERE week_start_date = $1 AND week_end_date = $2
+        RETURNING id
+      `;
+      
+      await client.query(updateQuery, [
+        weekData.week_start_date, weekData.week_end_date,
+        weekData.actual_weekly_revenue, weekData.weekly_revenue_goal,
+        weekData.actual_monthly_revenue, weekData.monthly_revenue_goal,
+        weekData.drip_iv_revenue_weekly, weekData.semaglutide_revenue_weekly,
+        weekData.ketamine_revenue_weekly, weekData.drip_iv_revenue_monthly,
+        weekData.semaglutide_revenue_monthly, weekData.ketamine_revenue_monthly,
+        weekData.ketamine_new_patient_weekly, weekData.ketamine_initial_booster_weekly,
+        weekData.ketamine_booster_pain_weekly, weekData.ketamine_booster_bh_weekly,
+        weekData.drip_iv_weekday_weekly, weekData.drip_iv_weekend_weekly,
+        weekData.drip_iv_weekday_monthly, weekData.drip_iv_weekend_monthly,
+        weekData.semaglutide_consults_weekly, weekData.semaglutide_injections_weekly,
+        weekData.semaglutide_consults_monthly, weekData.semaglutide_injections_monthly,
+        weekData.hormone_followup_female_weekly, weekData.hormone_initial_male_weekly,
+        weekData.hormone_followup_female_monthly, weekData.hormone_initial_male_monthly,
+        weekData.total_drip_iv_members, weekData.individual_memberships,
+        weekData.family_memberships, weekData.concierge_memberships,
+        weekData.corporate_memberships, weekData.ketamine_new_patient_monthly,
+        weekData.ketamine_initial_booster_monthly, weekData.ketamine_booster_pain_monthly,
+        weekData.ketamine_booster_bh_monthly, weekData.hubspot_ketamine_conversions,
+        weekData.marketing_initiatives, weekData.days_left_in_month,
+        weekData.unique_customers_weekly
+      ]);
+      
+    } else {
+      console.log('➕ Inserting new July 14-20 data...\n');
+      
+      // Insert new record
+      const insertQuery = `
+        INSERT INTO analytics_data (
+          week_start_date, week_end_date,
+          actual_weekly_revenue, weekly_revenue_goal,
+          actual_monthly_revenue, monthly_revenue_goal,
+          drip_iv_revenue_weekly, semaglutide_revenue_weekly, ketamine_revenue_weekly,
+          drip_iv_revenue_monthly, semaglutide_revenue_monthly, ketamine_revenue_monthly,
+          ketamine_new_patient_weekly, ketamine_initial_booster_weekly,
+          ketamine_booster_pain_weekly, ketamine_booster_bh_weekly,
+          drip_iv_weekday_weekly, drip_iv_weekend_weekly,
+          drip_iv_weekday_monthly, drip_iv_weekend_monthly,
+          semaglutide_consults_weekly, semaglutide_injections_weekly,
+          semaglutide_consults_monthly, semaglutide_injections_monthly,
+          hormone_followup_female_weekly, hormone_initial_male_weekly,
+          hormone_followup_female_monthly, hormone_initial_male_monthly,
+          total_drip_iv_members, individual_memberships, family_memberships,
+          conc

--- a/public/index.html
+++ b/public/index.html
@@ -471,7 +471,7 @@
                         <div class="tagline">Boost Your Energy • Burn Fat • Feel Energized</div>
                     </div>
                 </div>
-                <div class="date-range">Weekly Dashboard: July 14 - July 20, 2025</div>
+                <div class="date-range" id="dashboard-date-range">Weekly Dashboard: Loading...</div>
                 <div class="locations-badge">📍 Lafayette, LA</div>
                 <div style="margin-top: 25px;">
                     <div class="upload-section" onclick="document.getElementById('fileInput').click()">
@@ -600,7 +600,7 @@
                                 <div class="membership-count family-concierge-members">--</div>
                             </div>
                             <div class="membership-card">
-                                <h4>Drip & Concierge</h4>
+                                <h4>Drip Concierge</h4>
                                 <div class="membership-count drip-concierge-members">--</div>
                             </div>
                         </div>
@@ -738,7 +738,20 @@
                 
                 if (result.success && result.data) {
                     console.log('Data loaded successfully:', result.data);
+                    console.log('Membership data:', {
+                        individual: result.data.individual_memberships,
+                        family: result.data.family_memberships,
+                        concierge: result.data.concierge_memberships,
+                        corporate: result.data.corporate_memberships,
+                        family_concierge: result.data.family_concierge_memberships,
+                        drip_concierge: result.data.drip_concierge_memberships
+                    });
                     updateDashboard(result.data);
+                    
+                    // Update date range if data contains date information
+                    if (result.data.week_start_date && result.data.week_end_date) {
+                        updateDateRangeFromData(result.data.week_start_date, result.data.week_end_date);
+                    }
                 } else {
                     console.log('No data available:', result.message);
                     showNoDataState();
@@ -751,8 +764,18 @@
         
         // Update dashboard with data
         function updateDashboard(data) {
+            // Calculate total members from all membership types if not provided
+            const totalMembers = data.total_drip_iv_members || (
+                (data.individual_memberships || 0) +
+                (data.family_memberships || 0) +
+                (data.concierge_memberships || 0) +
+                (data.corporate_memberships || 0) +
+                (data.family_concierge_memberships || 0) +
+                (data.drip_concierge_memberships || 0)
+            );
+            
             // Update metric cards
-            updateElement('.total-members', data.total_drip_iv_members || 0);
+            updateElement('.total-members', totalMembers);
             updateElement('.hubspot-conversions', data.hubspot_ketamine_conversions || 0);
             updateElement('.marketing-initiatives', data.marketing_initiatives || 0);
             updateElement('.concierge-memberships', data.concierge_memberships || 0);
@@ -946,9 +969,54 @@
             });
         }
         
+        // Update the dashboard date range to show current week
+        function updateDateRange() {
+            const today = new Date();
+            const currentDay = today.getDay();
+            const diff = today.getDate() - currentDay + (currentDay === 0 ? -6 : 1); // adjust when day is sunday
+            const monday = new Date(today.setDate(diff));
+            const sunday = new Date(monday);
+            sunday.setDate(monday.getDate() + 6);
+            
+            const monthNames = ["January", "February", "March", "April", "May", "June",
+                "July", "August", "September", "October", "November", "December"
+            ];
+            
+            const formatDate = (date) => {
+                return `${monthNames[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
+            };
+            
+            const dateRangeText = `Weekly Dashboard: ${formatDate(monday)} - ${formatDate(sunday)}`;
+            const dateRangeElement = document.getElementById('dashboard-date-range');
+            if (dateRangeElement) {
+                dateRangeElement.textContent = dateRangeText;
+            }
+        }
+        
+        // Update date range from actual data
+        function updateDateRangeFromData(startDate, endDate) {
+            const start = new Date(startDate);
+            const end = new Date(endDate);
+            
+            const monthNames = ["January", "February", "March", "April", "May", "June",
+                "July", "August", "September", "October", "November", "December"
+            ];
+            
+            const formatDate = (date) => {
+                return `${monthNames[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
+            };
+            
+            const dateRangeText = `Weekly Dashboard: ${formatDate(start)} - ${formatDate(end)}`;
+            const dateRangeElement = document.getElementById('dashboard-date-range');
+            if (dateRangeElement) {
+                dateRangeElement.textContent = dateRangeText;
+            }
+        }
+        
         // Initialize dashboard when page loads
         document.addEventListener('DOMContentLoaded', function() {
             console.log('🌟 Drip IV Dashboard initializing...');
+            updateDateRange();
             setupFileUpload();
             addInteractiveEffects();
             loadDashboardData();

--- a/public/index.html
+++ b/public/index.html
@@ -472,7 +472,7 @@
                     </div>
                 </div>
                 <div class="date-range">Weekly Dashboard: July 14 - July 20, 2025</div>
-                <div class="locations-badge">📍 Baton Rouge & Lafayette, LA</div>
+                <div class="locations-badge">📍 Lafayette, LA</div>
                 <div style="margin-top: 25px;">
                     <div class="upload-section" onclick="document.getElementById('fileInput').click()">
                         <input type="file" id="fileInput" accept=".xlsx,.csv,.pdf" multiple>
@@ -602,6 +602,34 @@
                             <div class="membership-card">
                                 <h4>Drip & Concierge</h4>
                                 <div class="membership-count">--</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            
+            <!-- New Memberships This Week -->
+            <div class="section">
+                <div class="wellness-section">
+                    <div class="wellness-content">
+                        <h2 style="margin: 0 0 15px 0; font-size: 2rem; font-weight: 600;">New Memberships This Week</h2>
+                        <p style="margin-bottom: 0; opacity: 0.9; font-size: 1.1rem;">Fresh additions to our wellness community</p>
+                        <div class="membership-grid">
+                            <div class="membership-card">
+                                <h4>Individual</h4>
+                                <div class="membership-count new-individual-weekly">--</div>
+                            </div>
+                            <div class="membership-card">
+                                <h4>Family</h4>
+                                <div class="membership-count new-family-weekly">--</div>
+                            </div>
+                            <div class="membership-card">
+                                <h4>Concierge</h4>
+                                <div class="membership-count new-concierge-weekly">--</div>
+                            </div>
+                            <div class="membership-card">
+                                <h4>Corporate</h4>
+                                <div class="membership-count new-corporate-weekly">--</div>
                             </div>
                         </div>
                     </div>
@@ -765,6 +793,12 @@
             updateElement('.individual-members', data.total_drip_iv_members || 0);
             updateElement('.concierge-member-count', data.concierge_memberships || 0);
             updateElement('.corporate-member-count', data.corporate_memberships || 0);
+            
+            // Update new membership counts this week
+            updateElement('.new-individual-weekly', data.new_individual_members_weekly || 0);
+            updateElement('.new-family-weekly', data.new_family_members_weekly || 0);
+            updateElement('.new-concierge-weekly', data.new_concierge_members_weekly || 0);
+            updateElement('.new-corporate-weekly', data.new_corporate_members_weekly || 0);
             
             // Update service volume data
             updateElement('.ketamine-new-weekly', data.ketamine_new_patient_weekly || 0);

--- a/public/index.html
+++ b/public/index.html
@@ -585,7 +585,7 @@
                             </div>
                             <div class="membership-card">
                                 <h4>Family</h4>
-                                <div class="membership-count">--</div>
+                                <div class="membership-count family-members">--</div>
                             </div>
                             <div class="membership-card">
                                 <h4>Concierge</h4>
@@ -597,11 +597,11 @@
                             </div>
                             <div class="membership-card">
                                 <h4>Family & Concierge</h4>
-                                <div class="membership-count">--</div>
+                                <div class="membership-count family-concierge-members">--</div>
                             </div>
                             <div class="membership-card">
                                 <h4>Drip & Concierge</h4>
-                                <div class="membership-count">--</div>
+                                <div class="membership-count drip-concierge-members">--</div>
                             </div>
                         </div>
                     </div>
@@ -790,9 +790,12 @@
             updateElement('.monthly-progress-text', `${monthlyPercent}% of monthly goal achieved (${data.days_left_in_month || 0} days remaining)`);
             
             // Update membership counts
-            updateElement('.individual-members', data.total_drip_iv_members || 0);
+            updateElement('.individual-members', data.individual_memberships || 0);
+            updateElement('.family-members', data.family_memberships || 0);
             updateElement('.concierge-member-count', data.concierge_memberships || 0);
             updateElement('.corporate-member-count', data.corporate_memberships || 0);
+            updateElement('.family-concierge-members', data.family_concierge_memberships || 0);
+            updateElement('.drip-concierge-members', data.drip_concierge_memberships || 0);
             
             // Update new membership counts this week
             updateElement('.new-individual-weekly', data.new_individual_members_weekly || 0);


### PR DESCRIPTION
## Changes
- Added `load-august-data.js` script to import data for week of July 27 - August 2, 2025
- Fixed membership display in dashboard to show all 6 membership types
- Updated frontend to properly pull membership data from database

## Data Being Loaded
- Weekly Revenue: $32,219.95
- Total Drip IV Members: 139
- Individual Memberships: 103
- Family Memberships: 17
- Concierge Memberships: 15
- Corporate Memberships: 1
- Unique Customers: 161

## How to Use
After deploying, run:
```bash
node load-august-data.js
```