### PR TITLE
Handle payment-date-only rows in revenue binning

### DIFF
--- a/test-revenue-fix.js
+++ b/test-revenue-fix.js
@@ -26,11 +26,12 @@ async function testRevenueFix() {
     console.log('📊 Processing revenue data from CSV...\n');
     
     // Process the CSV data
-    const csvData = await processRevenueData(csvPath);
+    const csvResult = await processRevenueData(csvPath);
+    const csvData = csvResult.rawRows || [];
     console.log(`✅ Loaded ${csvData.length} rows from CSV\n`);
-    
+
     // Analyze with fixed logic
-    const metrics = analyzeRevenueData(csvData);
+    const metrics = await analyzeRevenueData(csvData);
     
     console.log('📈 ANALYSIS RESULTS:');
     console.log('=' .repeat(60));


### PR DESCRIPTION
## Summary
- add a shared helper that normalizes the date column for each revenue row, falling back to payment dates when necessary
- reuse the shared date resolver during both passes of revenue analysis so payment-date-only rows feed the weekly bin aggregates
- extend the categorization harness to assert the new payment-date fallback behaviour using analyzeRevenueData directly

## Testing
- node test-categorization.js
- node test-revenue-fix.js

------
https://chatgpt.com/codex/tasks/task_e_68e02934c5e48324a667fc09d9a24a9f