### PR TITLE
docs: audit HP3-122 package date import status

### DIFF
--- a/docs/project_notes/issues.md
+++ b/docs/project_notes/issues.md
@@ -116,3 +116,13 @@ Keep a lightweight log of work completed or in progress.
 - **Fix Applied**: Added `isExcluded = lowerDesc.includes('do not use')` to both import scripts
 - **Files Modified**: `import-weekly-data.js`, `import-multi-week-data.js`
 - **Expected Result**: IV Therapy should show $15,812.35 after re-upload ($16,041.35 - $229.00)
+
+### 2026-03-28 - HP3-122: Audit package date import status (R5-02)
+- **Status**: Blocked
+- **Description**: Reviewed project memory, codebase, and git history to verify whether `dateOfService` / `packageLaidDate` import for ~1,610 packages had already been completed.
+- **Findings**:
+  - No code paths, schema fields, or migration files in this repo currently reference `dateOfService` or `packageLaidDate`.
+  - No commit messages indicate prior Airtable package-date import work.
+  - Existing dashboard analytics schema is weekly aggregate-focused and does not include package-level date columns.
+- **Blocked On**: Ryan confirmation of Airtable source field mapping and export payload before implementation can begin.
+- **URL**: https://linear.app (HP3-122)


### PR DESCRIPTION
### Motivation
- Verify whether the Airtable import of package-level dates (`dateOfService` / `packageLaidDate`) required by HP3-122 has already been implemented or remains outstanding.
- Capture an audit result in project memory so the task can be unblocked once Airtable field mapping and export payload are provided.

### Description
- Added a new work-log entry to `docs/project_notes/issues.md` titled `2026-03-28 - HP3-122: Audit package date import status (R5-02)` documenting the audit findings and blocker status.
- The entry records that no code paths, schema fields, or migrations reference `dateOfService` or `packageLaidDate`, and no commits indicate prior Airtable package-date import work.
- Marked the task as blocked on confirmation of the Airtable source field mapping and export payload.
- The change is documentation-only; no application code or schema was modified.

### Testing
- Searched the codebase for `dateOfService` / `packageLaidDate` / `Airtable` and found no references, which succeeded.
- Inspected `database/schema.sql` for package-level date columns and found none, which succeeded.
- Reviewed repository history for related commits and found no evidence of prior work, which succeeded.
- Added and recorded the documentation update in the working branch (local commit succeeded) and an attempt to push to a remote failed because no remote push destination is configured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c72d57a7cc832493e7a5751c94c122)